### PR TITLE
Remove unused method on ApiDto

### DIFF
--- a/api/src/main/java/com/codeforcommunity/dto/ApiDto.java
+++ b/api/src/main/java/com/codeforcommunity/dto/ApiDto.java
@@ -30,23 +30,6 @@ public abstract class ApiDto {
   public abstract List<String> validateFields(String fieldPrefix) throws HandledException;
 
   /**
-   * Verify if the extending DTO is a valid object. This version should be overridden if this object
-   * has sometimes-optional fields. For an example, see {@code EventDetails} in Lucy's Love Bus.
-   *
-   * @param fieldPrefix A string to prefix each field with 9for use if this is a sub-field). Should
-   *     be of the form "OBJECT.".
-   * @param nullable a boolean representing whether this is the nullable version of an object with
-   *     sometimes-optional fields.
-   * @return A list of strings containing the fields that are invalid. Return a non-null empty list
-   *     if all fields are valid.
-   * @throws HandledException if an issue comes up with a field that would not otherwise fall under
-   *     a {@link MalformedParameterException}.
-   */
-  public List<String> validateFields(String fieldPrefix, boolean nullable) throws HandledException {
-    return validateFields(fieldPrefix);
-  }
-
-  /**
    * Validate the extending DTO. Calls validateFields, joins the list of fields, and throws a {@link
    * HandledException} containing the field(s) that caused the issue. Can be overridden if another
    * {@link HandledException} should be thrown.


### PR DESCRIPTION
IntelliJ reports no usages of this function. Its implementation just calls the other function. 