### PR TITLE
Update logout to ignore duplicate refresh key

### DIFF
--- a/service/src/main/java/com/codeforcommunity/dataaccess/AuthDatabaseOperations.java
+++ b/service/src/main/java/com/codeforcommunity/dataaccess/AuthDatabaseOperations.java
@@ -122,7 +122,10 @@ public class AuthDatabaseOperations {
   /** Given a JWT signature, store it in the BLACKLISTED_REFRESHES table. */
   public void addToBlackList(String signature) {
     Timestamp expirationTimestamp = Timestamp.from(Instant.now().plusMillis(msRefreshExpiration));
-    db.newRecord(Tables.BLACKLISTED_REFRESHES).values(signature, expirationTimestamp).store();
+    db.insertInto(Tables.BLACKLISTED_REFRESHES)
+        .values(signature, expirationTimestamp)
+        .onDuplicateKeyIgnore()
+        .execute();
   }
 
   /** Given a JWT signature return true if it is stored in the BLACKLISTED_REFRESHES table. */


### PR DESCRIPTION
Update the logout out to insert blacklist refresh only if the refresh hash is unique.

This is to fix the following issue:

```
[Hands Across the Sea] [com.codeforcommunity.rest.FailureHandler] Internal server error caused by: SQL [insert into "blacklisted_refreshes" ("refresh_hash", "created_at", "updated_at", "expires") values (?, cast(? as timestamp), cast(? as timestamp), cast(? as timestamp)) returning "blacklisted_refreshes"."refresh_hash"]; ERROR: duplicate key value violates unique constraint "blacklisted_refreshes_pkey"
 Detail: Key (refresh_hash)=(pPmYUbDb07x5VAnJGe1DJiQjHSIk30SZ6pGvroPPEuA) already exists.
com.codeforcommunity.rest.FailureHandler.handleUncaughtError(FailureHandler.java:219)
```